### PR TITLE
Supported customized extension name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+_1.2.2 — October 4, 2018_
+* enabled "extension" attribute in the {{#extends}} to support the customization of extension name
+
 _1.2.1 — Febrary 8, 2018_
 
 * updated dependancies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wax-on",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Add support to Handlebars for template inheritance with the `block` and `extends` helpers.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The extension name was hardcoded as "hbs". However, "handlebars" is also a common extension name for the Handlebars.js template. Thus, this PR supports to overwrite the default one with a customized extension name while using the `extends` syntax.

```javascript
{{#extends "base_layout" extension="handlebars"}}{{/extends}}
```